### PR TITLE
Mention localhost-only default (security)

### DIFF
--- a/documentation/configuration-general.md
+++ b/documentation/configuration-general.md
@@ -18,6 +18,8 @@ Each release of Postgres.app comes with the latest stable release of PostgreSQL,
 - **Password:** *blank*
 - **Database:** *same as user name*
 
+### Connection security
+Postgresql (and Postgres.app) default to only localhost connections, configurable by [listen_addresses](http://www.postgresql.org/docs/current/static/runtime-config-connection.html) –  'The default value is localhost, which allows only local TCP/IP "loopback" connections to be made'.
 
 ## Useful Directories
 


### PR DESCRIPTION
I was wondering about this, and think it'd be nice to mention in the readme.

I'm assuming I've found the [correct config file](http://iamvery.com/2013/06/17/postgresapp-with-unix-socket.html) at /Users/nruth/Library/Application Support/Postgres/var-9.4/postgresql.conf (I'm on 9.4).

Rewording/copy-editing suggestions are welcome.