### PR TITLE
Document postgresql.conf location

### DIFF
--- a/documentation/configuration-general.md
+++ b/documentation/configuration-general.md
@@ -26,4 +26,5 @@ Each release of Postgres.app comes with the latest stable release of PostgreSQL,
 - Headers: `/Applications/Postgres.app/Contents/Versions/9.5/include`
 - Libraries: `/Applications/Postgres.app/Contents/Versions/9.5/lib`
 - Man pages: `/Applications/Postgres.app/Contents/Versions/9.5/share`
+- Config: `~/Library/Application\ Support/Postgres/var-9.5/postgresql.conf`
 


### PR DESCRIPTION
[There seems to be some confusion about this](http://iamvery.com/2013/06/17/postgresapp-with-unix-socket.html), and it'd be nice to have an answer in the docs.

Since this is a zero-config installer it's not necessarily a good idea – misconfiguration may break the app – but it's useful to be able to check things like if it's accepting sockets, if it's listening to 0.0.0.0 and so on.

I tried changing port 5432 to 5433, and restarting the server did change the port, so it looks like it's the right config path (tested with version 9.4).