### PR TITLE
Fix Java tables

### DIFF
--- a/de/documentation/configuration-java.md
+++ b/de/documentation/configuration-java.md
@@ -25,12 +25,11 @@ Du kannst den [PostgreSQL JDBC driver](https://jdbc.postgresql.org/download.html
 
 Stelle sicher dass die JDBC-Version zu deiner Java-Version passt:
 
-<table border=1 cellpadding=4>
-	<tr><th>Java Version</th><th>JDBC Version</th></tr>
-	<tr><td>Java 1.6</td><td>JDBC 4.0</td></tr>
-	<tr><td>Java 1.7</td><td>JDBC 4.1</td></tr>
-	<tr><td>Java 1.8</td><td>JDBC 4.2</td></tr>
-</table>
+| Java Version | JDBC Version |
+| ------------ | ------------ |
+| Java 1.6     | JDBC 4.0     |
+| Java 1.7     | JDBC 4.1     |
+| Java 1.8     | JDBC 4.2     |
 
 Mehr info gibt es im Kapitel [Connecting to the Database](https://jdbc.postgresql.org/documentation/head/connect.html) in der offiziellen Dokumentation (auf Englisch).
 

--- a/documentation/configuration-java.md
+++ b/documentation/configuration-java.md
@@ -25,12 +25,11 @@ The easiest way to get the [PostgreSQL JDBC driver](https://jdbc.postgresql.org/
 
 Make sure the JDBC version of the driver matches your Java version.
 
-<table border=1 cellpadding=4>
-	<tr><th>Java Version</th><th>JDBC Version</th></tr>
-	<tr><td>Java 1.6</td><td>JDBC 4.0</td></tr>
-	<tr><td>Java 1.7</td><td>JDBC 4.1</td></tr>
-	<tr><td>Java 1.8</td><td>JDBC 4.2</td></tr>
-</table>
+| Java Version | JDBC Version |
+| ------------ | ------------ |
+| Java 1.6     | JDBC 4.0     |
+| Java 1.7     | JDBC 4.1     |
+| Java 1.8     | JDBC 4.2     |
 
 For more information check out the [Connecting to the Database](https://jdbc.postgresql.org/documentation/head/connect.html) chapter of the official documentation.
 


### PR DESCRIPTION
Somehow the HTML tables in the Java chapters no longer work.
Switching to Markdown hopefully fixes this.