### PR TITLE
Tidy up some links.

### DIFF
--- a/de/documentation/index.md
+++ b/de/documentation/index.md
@@ -23,5 +23,5 @@ Ob du lieber auf der Kommandozeile arbeitest order graphische Benutzeroberfläch
 ## Weiterführende Informationen
 
 - [PostgreSQL Webseite](http://www.postgresql.org/) - Die offizielle Webseite von PostgreSQL (Englisch)
-- [PostgreSQL Documentation](http://www.postgresql.org/docs/9.5/interactive/index.html) - Das offizielle Benutzerhandbuch für PostgreSQL (Englisch)
+- [PostgreSQL Documentation](http://www.postgresql.org/docs/current/static/index.html) - Das offizielle Benutzerhandbuch für PostgreSQL (Englisch)
 

--- a/de/index.md
+++ b/de/index.md
@@ -40,8 +40,8 @@ Postgres.app enthält eine vollständige Installation die keine Wünsche offen l
 
 - [PostgreSQL](http://www.postgresql.org) {{site.postgresqlVersion}}
 - [PostGIS](http://postgis.net) {{site.postgisVersion}}
-- Unterstüzte Sprachen für Stored Procedures: [PL/pgSQL](http://www.postgresql.org/docs/9.5/static/plpgsql.html), [PL/Perl](http://www.postgresql.org/docs/9.5/static/plperl.html), [PL/Python](http://www.postgresql.org/docs/9.5/static/plpython.html), und [PLV8 (Javascript)](https://github.com/plv8/plv8)
-- Beliebte Erweiterungen wie [hstore](http://www.postgresql.org/docs/9.5/static/hstore.html) und [uuid-ossp](http://www.postgresql.org/docs/9.5/static/uuid-ossp.html), und mehr!
+- Unterstüzte Sprachen für Stored Procedures: [PL/pgSQL](http://www.postgresql.org/docs/current/static/plpgsql.html), [PL/Perl](http://www.postgresql.org/docs/current/static/plperl.html), [PL/Python](http://www.postgresql.org/docs/current/static/plpython.html), und [PLV8 (Javascript)](https://github.com/plv8/plv8)
+- Beliebte Erweiterungen wie [hstore](http://www.postgresql.org/docs/current/static/hstore.html) und [uuid-ossp](http://www.postgresql.org/docs/current/static/uuid-ossp.html), und mehr!
 - Viele [Tools für die Kommandozeile](/documentation/cli-tools.html), für PostgreSQL und GIS-Anwendungen
 
 Andere Versionen

--- a/de/index.md
+++ b/de/index.md
@@ -40,8 +40,8 @@ Postgres.app enthält eine vollständige Installation die keine Wünsche offen l
 
 - [PostgreSQL](http://www.postgresql.org) {{site.postgresqlVersion}}
 - [PostGIS](http://postgis.net) {{site.postgisVersion}}
-- Unterstüzte Sprachen für Stored Procedures: [PL/pgSQL](http://www.postgresql.org/docs/9.5/static/plpgsql.html), [PL/Perl](http://www.postgresql.org/docs/9.5/static/plperl.html), [PL/Python](http://www.postgresql.org/docs/9.5/static/plpython.html), und [PLV8 (Javascript)](https://code.google.com/p/plv8js/wiki/PLV8)
-- Beliebte Erweiterungen wie [hstore](http://www.postgresql.org/docs/9.5/static/hstore.html) und [uuid-ossp](http://www.postgresql.org/docs/devel/static/uuid-ossp.html), und mehr!
+- Unterstüzte Sprachen für Stored Procedures: [PL/pgSQL](http://www.postgresql.org/docs/9.5/static/plpgsql.html), [PL/Perl](http://www.postgresql.org/docs/9.5/static/plperl.html), [PL/Python](http://www.postgresql.org/docs/9.5/static/plpython.html), und [PLV8 (Javascript)](https://github.com/plv8/plv8)
+- Beliebte Erweiterungen wie [hstore](http://www.postgresql.org/docs/9.5/static/hstore.html) und [uuid-ossp](http://www.postgresql.org/docs/9.5/static/uuid-ossp.html), und mehr!
 - Viele [Tools für die Kommandozeile](/documentation/cli-tools.html), für PostgreSQL und GIS-Anwendungen
 
 Andere Versionen

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -22,5 +22,5 @@ Whether you're a command line aficionado, prefer GUIs, or just want to start mak
 ## Additional Resources
 
 - [PostgreSQL Website](http://www.postgresql.org/) - The source for all of the latest PostgreSQL news and information.
-- [PostgreSQL Docs](http://www.postgresql.org/docs/9.3/interactive/index.html) - The canonical reference for everything you need to know about PostgreSQL.
+- [PostgreSQL Docs](http://www.postgresql.org/docs/current/static/index.html) - The canonical reference for everything you need to know about PostgreSQL.
 - [Postgres Guide](http://postgresguide.com/) - A promising new PostgreSQL resource that reads well and introduces advanced topics in a way that's easy to understand.

--- a/download/index.html
+++ b/download/index.html
@@ -1,7 +1,3 @@
----
-layout: redirect
----
-
 {% assign url = "https://github.com/PostgresApp/PostgresApp/releases/latest" %}
 
 <!DOCTYPE html>

--- a/index.md
+++ b/index.md
@@ -41,8 +41,8 @@ Postgres.app contains a full-featured PostgreSQL installation in a single packag
 
 - [PostgreSQL](http://www.postgresql.org) {{site.postgresqlVersion}}
 - [PostGIS](http://postgis.net) {{site.postgisVersion}}
-- Procedural languages: [PL/pgSQL](http://www.postgresql.org/docs/9.5/static/plpgsql.html), [PL/Perl](http://www.postgresql.org/docs/9.5/static/plperl.html), [PL/Python](http://www.postgresql.org/docs/9.5/static/plpython.html), and [PLV8 (Javascript)](https://github.com/plv8/plv8)
-- Popular extensions, including [hstore](http://www.postgresql.org/docs/9.5/static/hstore.html) and [uuid-ossp](http://www.postgresql.org/docs/9.5/static/uuid-ossp.html), and more
+- Procedural languages: [PL/pgSQL](http://www.postgresql.org/docs/current/static/plpgsql.html), [PL/Perl](http://www.postgresql.org/docs/current/static/plperl.html), [PL/Python](http://www.postgresql.org/docs/current/static/plpython.html), and [PLV8 (Javascript)](https://github.com/plv8/plv8)
+- Popular extensions, including [hstore](http://www.postgresql.org/docs/current/static/hstore.html) and [uuid-ossp](http://www.postgresql.org/docs/current/static/uuid-ossp.html), and more
 - A number of [command-line utilities](documentation/cli-tools.html) for managing PostgreSQL and working with GIS data
 
 Other versions

--- a/index.md
+++ b/index.md
@@ -41,8 +41,8 @@ Postgres.app contains a full-featured PostgreSQL installation in a single packag
 
 - [PostgreSQL](http://www.postgresql.org) {{site.postgresqlVersion}}
 - [PostGIS](http://postgis.net) {{site.postgisVersion}}
-- Procedural languages: [PL/pgSQL](http://www.postgresql.org/docs/9.5/static/plpgsql.html), [PL/Perl](http://www.postgresql.org/docs/9.5/static/plperl.html), [PL/Python](http://www.postgresql.org/docs/9.5/static/plpython.html), and [PLV8 (Javascript)](https://code.google.com/p/plv8js/wiki/PLV8)
-- Popular extensions, including [hstore](http://www.postgresql.org/docs/9.5/static/hstore.html) and [uuid-ossp](http://www.postgresql.org/docs/devel/static/uuid-ossp.html), and more
+- Procedural languages: [PL/pgSQL](http://www.postgresql.org/docs/9.5/static/plpgsql.html), [PL/Perl](http://www.postgresql.org/docs/9.5/static/plperl.html), [PL/Python](http://www.postgresql.org/docs/9.5/static/plpython.html), and [PLV8 (Javascript)](https://github.com/plv8/plv8)
+- Popular extensions, including [hstore](http://www.postgresql.org/docs/9.5/static/hstore.html) and [uuid-ossp](http://www.postgresql.org/docs/9.5/static/uuid-ossp.html), and more
 - A number of [command-line utilities](documentation/cli-tools.html) for managing PostgreSQL and working with GIS data
 
 Other versions


### PR DESCRIPTION
Link to version 9.5 of uuid-osp rather than devel, to plv8 on
github rather than the redirect via code.google.com and link
to 'current' docs rather than 9.3.